### PR TITLE
Change codec so it does not crashed on func

### DIFF
--- a/erlastic/codec.py
+++ b/erlastic/codec.py
@@ -70,6 +70,12 @@ class ErlangTermDecoder(object):
             items.append(val)
         return tuple(items), offset
 
+    def decode_p(self, bytes, offset = 0):
+        """Decode NEW_FUN_EXT"""
+        size = struct.unpack(">L", bytes[offset:offset+4])[0]
+        arity = ord(bytes[4])
+        return "f/%d"%(arity), offset+size
+
     def decode_i(self, bytes, offset):
         """LARGE_TUPLE_EXT"""
         arity = struct.unpack(">L", bytes[offset:offset+4])[0]


### PR DESCRIPTION
Currently Bert crashes when faced with an Erlang fun (http://erlang.org/doc/apps/erts/erl_ext_dist.html#id90022). I am not sure what the appropriate decoding for a fun is, but mostly I find it useful if I can actually read the file (I don't think it makes sense to try and run a fun on Python).

This code just adds enough to skip the NEW_FUN_EXT terms in a Bert blob.
