### PR TITLE
Compatibility with Python >= 2.6

### DIFF
--- a/erlastic/__init__.py
+++ b/erlastic/__init__.py
@@ -15,7 +15,7 @@ import sys
 def mailbox_gen():
   while True:
     len_bin = sys.stdin.buffer.read(4)
-    if len(len_bin) != 4: return None
+    if len(len_bin) != 4: return
     (length,) = struct.unpack('!I',len_bin)
     yield decode(sys.stdin.buffer.read(length))
 def port_gen():

--- a/erlastic/codec.py
+++ b/erlastic/codec.py
@@ -57,7 +57,7 @@ class ErlangTermDecoder(object):
 
     def decode_115(self, buf, offset):
         """SMALL_ATOM_EXT"""
-        atom_len = six.intexbytes(buf, offset)
+        atom_len = six.indexbytes(buf, offset)
         atom = buf[offset+1:offset+1+atom_len]
         return self.convert_atom(atom), offset+atom_len+1
 

--- a/erlastic/compat.py
+++ b/erlastic/compat.py
@@ -1,0 +1,10 @@
+import sys
+
+from array import array
+
+__all__ = ['pack_bytes']
+
+if sys.version_info < (3,):
+    pack_bytes = lambda a: array('B', a).tostring()
+else:
+    pack_bytes = bytes

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     author_email = 'samuel@descolada.com',
     url = 'http://github.com/samuel/python-erlastic',
     packages = ['erlastic'],
+    install_requires=['six'],
     classifiers = [
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/tests.py
+++ b/tests.py
@@ -1,58 +1,60 @@
 #!/usr/bin/env python
 
+import six
 import unittest
 
 from erlastic import decode, encode
+from erlastic.compat import *
 from erlastic.types import *
 
 erlang_term_binaries = [
     # nil
-    ([], list, b"\x83j"),
+    ([], list, six.b('\x83j')),
     # binary
-    (b"foo", bytes, b'\x83m\x00\x00\x00\x03foo'),
+    (six.b('foo'), six.binary_type, six.b('\x83m\x00\x00\x00\x03foo')),
     # atom
-    (Atom("foo"), Atom, b'\x83d\x00\x03foo'),
+    (Atom("foo"), Atom, six.b('\x83d\x00\x03foo')),
     # atom true
-    (True, bool, b'\x83d\x00\x04true'),
+    (True, bool, six.b('\x83d\x00\x04true')),
     # atom false
-    (False, bool, b'\x83d\x00\x05false'),
+    (False, bool, six.b('\x83d\x00\x05false')),
     # atom none
-    (None, type(None), b'\x83d\x00\x04none'),
+    (None, type(None), six.b('\x83d\x00\x04none')),
     # small integer
-    (123, int, b'\x83a{'),
+    (123, six.integer_types, six.b('\x83a{')),
     # integer
-    (12345, int, b'\x83b\x00\x0009'),
+    (12345, six.integer_types, six.b('\x83b\x00\x0009')),
     # float
-    (1.2345, float, b'\x83c1.23449999999999993072e+00\x00\x00\x00\x00\x00'),
+    (1.2345, float, six.b('\x83c1.23449999999999993072e+00\x00\x00\x00\x00\x00')),
     # tuple
-    ((Atom("foo"), b"test", 123), tuple, b'\x83h\x03d\x00\x03foom\x00\x00\x00\x04testa{'),
+    ((Atom("foo"), b"test", 123), tuple, six.b('\x83h\x03d\x00\x03foom\x00\x00\x00\x04testa{')),
     # list
-    ([1024, b"test", 4.096], list, b'\x83l\x00\x00\x00\x03b\x00\x00\x04\x00m\x00\x00\x00\x04testc4.09600000000000008527e+00\x00\x00\x00\x00\x00j'),
-    ([102, 111, 111], list, b'\x83l\x00\x00\x00\x03afaoaoj'),
+    ([1024, b"test", 4.096], list, six.b('\x83l\x00\x00\x00\x03b\x00\x00\x04\x00m\x00\x00\x00\x04testc4.09600000000000008527e+00\x00\x00\x00\x00\x00j')),
+    ([102, 111, 111], list, six.b('\x83l\x00\x00\x00\x03afaoaoj')),
     # small big
-    (12345678901234567890, int, b'\x83n\x08\x00\xd2\n\x1f\xeb\x8c\xa9T\xab'),
+    (12345678901234567890, six.integer_types, six.b('\x83n\x08\x00\xd2\n\x1f\xeb\x8c\xa9T\xab')),
     # large big
     (123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890,
-     int, b'\x83o\x00\x00\x01D\x00\xd2\n?\xce\x96\xf1\xcf\xacK\xf1{\xefa\x11=$^\x93\xa9\x88\x17\xa0\xc2\x01\xa5%\xb7\xe3Q\x1b\x00\xeb\xe7\xe5\xd5Po\x98\xbd\x90\xf1\xc3\xddR\x83\xd1)\xfc&\xeaH\xc31w\xf1\x07\xf3\xf33\x8f\xb7\x96\x83\x05t\xeci\x9cY"\x98\x98i\xca\x11bY=\xcc\xa1\xb4R\x1bl\x01\x86\x18\xe9\xa23\xaa\x14\xef\x11[}O\x14RU\x18$\xfe\x7f\x96\x94\xcer?\xd7\x8b\x9a\xa7v\xbd\xbb+\x07X\x94x\x7fI\x024.\xa0\xcc\xde\xef:\xa7\x89~\xa4\xafb\xe4\xc1\x07\x1d\xf3cl|0\xc9P`\xbf\xab\x95z\xa2DQf\xf7\xca\xef\xb0\xc4=\x11\x06*:Y\xf58\xaf\x18\xa7\x81\x13\xdf\xbdTl4\xe0\x00\xee\x93\xd6\x83V\xc9<\xe7I\xdf\xa8.\xf5\xfc\xa4$R\x95\xef\xd1\xa7\xd2\x89\xceu!\xf8\x08\xb1Zv\xa6\xd9z\xdb0\x88\x10\xf3\x7f\xd3sc\x98[\x1a\xac6V\x1f\xad0)\xd0\x978\xd1\x02\xe6\xfbH\x149\xdc).\xb5\x92\xf6\x91A\x1b\xcd\xb8`B\xc6\x04\x83L\xc0\xb8\xafN+\x81\xed\xec?;\x1f\xab1\xc1^J\xffO\x1e\x01\x87H\x0f.ZD\x06\xf0\xbak\xaagVH]\x17\xe6I.B\x14a2\xc1;\xd1+\xea.\xe4\x92\x15\x93\xe9\'E\xd0(\xcd\x90\xfb\x10'),
+     six.integer_types, six.b('\x83o\x00\x00\x01D\x00\xd2\n?\xce\x96\xf1\xcf\xacK\xf1{\xefa\x11=$^\x93\xa9\x88\x17\xa0\xc2\x01\xa5%\xb7\xe3Q\x1b\x00\xeb\xe7\xe5\xd5Po\x98\xbd\x90\xf1\xc3\xddR\x83\xd1)\xfc&\xeaH\xc31w\xf1\x07\xf3\xf33\x8f\xb7\x96\x83\x05t\xeci\x9cY"\x98\x98i\xca\x11bY=\xcc\xa1\xb4R\x1bl\x01\x86\x18\xe9\xa23\xaa\x14\xef\x11[}O\x14RU\x18$\xfe\x7f\x96\x94\xcer?\xd7\x8b\x9a\xa7v\xbd\xbb+\x07X\x94x\x7fI\x024.\xa0\xcc\xde\xef:\xa7\x89~\xa4\xafb\xe4\xc1\x07\x1d\xf3cl|0\xc9P`\xbf\xab\x95z\xa2DQf\xf7\xca\xef\xb0\xc4=\x11\x06*:Y\xf58\xaf\x18\xa7\x81\x13\xdf\xbdTl4\xe0\x00\xee\x93\xd6\x83V\xc9<\xe7I\xdf\xa8.\xf5\xfc\xa4$R\x95\xef\xd1\xa7\xd2\x89\xceu!\xf8\x08\xb1Zv\xa6\xd9z\xdb0\x88\x10\xf3\x7f\xd3sc\x98[\x1a\xac6V\x1f\xad0)\xd0\x978\xd1\x02\xe6\xfbH\x149\xdc).\xb5\x92\xf6\x91A\x1b\xcd\xb8`B\xc6\x04\x83L\xc0\xb8\xafN+\x81\xed\xec?;\x1f\xab1\xc1^J\xffO\x1e\x01\x87H\x0f.ZD\x06\xf0\xbak\xaagVH]\x17\xe6I.B\x14a2\xc1;\xd1+\xea.\xe4\x92\x15\x93\xe9\'E\xd0(\xcd\x90\xfb\x10')),
     # reference
-    (Reference('nonode@nohost', [33, 0, 0], 0), Reference, b'\x83r\x00\x03d\x00\rnonode@nohost\x00\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00'),
+    (Reference('nonode@nohost', [33, 0, 0], 0), Reference, six.b('\x83r\x00\x03d\x00\rnonode@nohost\x00\x00\x00\x00!\x00\x00\x00\x00\x00\x00\x00\x00')),
     # port
-    (Port('nonode@nohost', 455, 0), Port, b'\x83fd\x00\rnonode@nohost\x00\x00\x01\xc7\x00'),
+    (Port('nonode@nohost', 455, 0), Port, six.b('\x83fd\x00\rnonode@nohost\x00\x00\x01\xc7\x00')),
     # pid
-    (PID('nonode@nohost', 31, 0, 0), PID, b'\x83gd\x00\rnonode@nohost\x00\x00\x00\x1f\x00\x00\x00\x00\x00'),
+    (PID('nonode@nohost', 31, 0, 0), PID, six.b('\x83gd\x00\rnonode@nohost\x00\x00\x00\x1f\x00\x00\x00\x00\x00')),
     # function export
-    (Export('jobqueue', 'stats', 0), Export, b'\x83qd\x00\x08jobqueued\x00\x05statsa\x00'),
+    (Export('jobqueue', 'stats', 0), Export, six.b('\x83qd\x00\x08jobqueued\x00\x05statsa\x00')),
 ]
 
 erlang_term_decode = [
     ## ext_string is an optimized way to send list of bytes, so not bijective (no erlang representation), only decode
-    (bytes([102, 111, 111]), bytes, b'\x83k\x00\x03foo')
+    (pack_bytes([102, 111, 111]), six.binary_type, six.b('\x83k\x00\x03foo'))
 ]
 
 
 erlang_term_encode = [
-    ## python3 choice : encode string as binary utf-8, so not bijective (decoded binary utf-8 is of type "bytes()"), only encode
-    ("foo", str, b'\x83m\x00\x00\x00\x03foo')
+    ## python3 choice : encode string as binary utf-8, so not bijective (decoded binary utf-8 is of type "six.binary_type"), only encode
+    ("foo", six.string_types, six.b('\x83m\x00\x00\x00\x03foo'))
 ]
 
 class ErlangTestCase(unittest.TestCase):


### PR DESCRIPTION
Hi there,

In our project we have to use python-bert library, which relies on python-erlastic one, which in turn is not compatible with Python 2.x. I've made it compatible mainly by using six library.

If there are any problems with this pull request, please let me know, I would be more than happy to amend it.

Thank you!

Ivan.
