### PR TITLE
Eliminate one blind except

### DIFF
--- a/erlastic/codec.py
+++ b/erlastic/codec.py
@@ -20,7 +20,7 @@ class ErlangTermDecoder(object):
             v = getattr(self, k)
             if callable(v) and k.startswith('decode_'):
                 try: self.decoders[int(k.split('_')[1])] = v
-                except: pass
+                except Exception: pass
 
     def decode(self, buf, offset=0):
         version = buf[offset]


### PR DESCRIPTION
As far as I know it _could_ happen that an exception like
KeyboardInterrupt or SystemExit was caught by that blind except clause
(as unlikely as it is).
